### PR TITLE
[Feature] 멱등키를 이용한 멱등성 확보

### DIFF
--- a/src/main/java/com/irum/paymentservice/domain/payment/domain/entity/Payment.java
+++ b/src/main/java/com/irum/paymentservice/domain/payment/domain/entity/Payment.java
@@ -45,6 +45,8 @@ public class Payment extends BaseEntity {
 
     private Long memberId;
 
+    private String idempotencyKey;
+
     public void updateStatus(PaymentStatus paymentStatus) {
         this.paymentStatus = paymentStatus;
     }

--- a/src/main/java/com/irum/paymentservice/domain/payment/internal/service/PaymentInternalService.java
+++ b/src/main/java/com/irum/paymentservice/domain/payment/internal/service/PaymentInternalService.java
@@ -10,6 +10,7 @@ import com.irum.paymentservice.domain.payment.domain.entity.enums.PaymentStatus;
 import com.irum.paymentservice.domain.payment.domain.repository.PaymentRepository;
 import com.irum.paymentservice.domain.payment.internal.PaymentResponseMapper;
 import com.irum.paymentservice.global.exception.errorcode.PaymentErrorCode;
+import com.irum.paymentservice.global.util.IdempotencyKeyUtil;
 import com.irum.paymentservice.global.util.MemberUtil;
 import java.util.UUID;
 import lombok.RequiredArgsConstructor;
@@ -38,6 +39,7 @@ public class PaymentInternalService {
                         .totalDiscountAmount(request.discountAmount())
                         .paymentStatus(PaymentStatus.PENDING)
                         .paymentCorp(PaymentCorp.valueOf(request.paymentCorp().toString()))
+                        .idempotencyKey(IdempotencyKeyUtil.generateKey())
                         .build();
         log.info("[비즈니스] payment 생성: {}", payment);
 

--- a/src/main/java/com/irum/paymentservice/domain/payment/service/PaymentService.java
+++ b/src/main/java/com/irum/paymentservice/domain/payment/service/PaymentService.java
@@ -30,7 +30,6 @@ public class PaymentService {
     private final TosspaymentsAPI tosspaymentsAPI;
     private final PaymentRepository paymentRepository;
     private final MemberUtil memberUtil;
-    private final OrderAPI orderAPI;
     private final PaymentStatusService paymentStatusService;
     private final PaymentEventProducer paymentEventProducer;
 
@@ -51,7 +50,7 @@ public class PaymentService {
         try {
             // 토스 페이먼츠 승인 API호출
             TossPaymentsResponse tossPaymentsResponse =
-                    tosspaymentsAPI.confirmPayment(request, payment.getAmount());
+                    tosspaymentsAPI.confirmPayment(request, payment.getAmount(), payment.getIdempotencyKey());
             log.info("[외부] 토스 페이먼츠 승인 완료");
 
             // 상태 업데이트

--- a/src/main/java/com/irum/paymentservice/domain/payment/service/PaymentService.java
+++ b/src/main/java/com/irum/paymentservice/domain/payment/service/PaymentService.java
@@ -13,7 +13,6 @@ import com.irum.paymentservice.domain.payment.producer.PaymentEventProducer;
 import com.irum.paymentservice.global.exception.errorcode.GlobalErrorCode;
 import com.irum.paymentservice.global.exception.errorcode.PaymentErrorCode;
 import com.irum.paymentservice.global.util.MemberUtil;
-import com.irum.paymentservice.openfeign.order.OrderAPI;
 import com.irum.paymentservice.openfeign.toss.TosspaymentsAPI;
 import com.irum.paymentservice.openfeign.toss.dto.TossPaymentsResponse;
 import feign.FeignException;
@@ -50,7 +49,8 @@ public class PaymentService {
         try {
             // 토스 페이먼츠 승인 API호출
             TossPaymentsResponse tossPaymentsResponse =
-                    tosspaymentsAPI.confirmPayment(request, payment.getAmount(), payment.getIdempotencyKey());
+                    tosspaymentsAPI.confirmPayment(
+                            request, payment.getAmount(), payment.getIdempotencyKey());
             log.info("[외부] 토스 페이먼츠 승인 완료");
 
             // 상태 업데이트

--- a/src/main/java/com/irum/paymentservice/global/util/IdempotencyKeyUtil.java
+++ b/src/main/java/com/irum/paymentservice/global/util/IdempotencyKeyUtil.java
@@ -1,0 +1,13 @@
+package com.irum.paymentservice.global.util;
+
+import java.util.UUID;
+
+public class IdempotencyKeyUtil {
+    /**
+     * UUID v4 형식의 고유한 멱등키를 생성합니다.
+     * @return String 형태의 멱등키
+     */
+    public static String generateKey() {
+        return UUID.randomUUID().toString();
+    }
+}

--- a/src/main/java/com/irum/paymentservice/global/util/IdempotencyKeyUtil.java
+++ b/src/main/java/com/irum/paymentservice/global/util/IdempotencyKeyUtil.java
@@ -5,6 +5,7 @@ import java.util.UUID;
 public class IdempotencyKeyUtil {
     /**
      * UUID v4 형식의 고유한 멱등키를 생성합니다.
+     *
      * @return String 형태의 멱등키
      */
     public static String generateKey() {

--- a/src/main/java/com/irum/paymentservice/openfeign/toss/TosspaymentsAPI.java
+++ b/src/main/java/com/irum/paymentservice/openfeign/toss/TosspaymentsAPI.java
@@ -18,7 +18,8 @@ public class TosspaymentsAPI {
     private final TossProperties tossProperties;
     private final TosspaymentsClient tosspaymentsClient;
 
-    public TossPaymentsResponse confirmPayment(PaymentRequest request, int paymentAmount, String idempotencyKey) {
+    public TossPaymentsResponse confirmPayment(
+            PaymentRequest request, int paymentAmount, String idempotencyKey) {
         Base64.Encoder encoder = Base64.getEncoder();
         byte[] encodedBytes =
                 encoder.encode((tossProperties.secretKey() + ":").getBytes(StandardCharsets.UTF_8));
@@ -30,7 +31,7 @@ public class TosspaymentsAPI {
                         request.tossPaymentKey(), request.tossOrderId(), paymentAmount);
         log.info("Toss Payment Request: {}", tossPaymentsRequest.toString());
 
-
-        return tosspaymentsClient.confirmPayment(idempotencyKey, authorizations, tossPaymentsRequest);
+        return tosspaymentsClient.confirmPayment(
+                idempotencyKey, authorizations, tossPaymentsRequest);
     }
 }

--- a/src/main/java/com/irum/paymentservice/openfeign/toss/TosspaymentsAPI.java
+++ b/src/main/java/com/irum/paymentservice/openfeign/toss/TosspaymentsAPI.java
@@ -18,7 +18,7 @@ public class TosspaymentsAPI {
     private final TossProperties tossProperties;
     private final TosspaymentsClient tosspaymentsClient;
 
-    public TossPaymentsResponse confirmPayment(PaymentRequest request, int paymentAmount) {
+    public TossPaymentsResponse confirmPayment(PaymentRequest request, int paymentAmount, String idempotencyKey) {
         Base64.Encoder encoder = Base64.getEncoder();
         byte[] encodedBytes =
                 encoder.encode((tossProperties.secretKey() + ":").getBytes(StandardCharsets.UTF_8));
@@ -29,6 +29,8 @@ public class TosspaymentsAPI {
                 new TossPaymentsRequest(
                         request.tossPaymentKey(), request.tossOrderId(), paymentAmount);
         log.info("Toss Payment Request: {}", tossPaymentsRequest.toString());
-        return tosspaymentsClient.confirmPayment(authorizations, tossPaymentsRequest);
+
+
+        return tosspaymentsClient.confirmPayment(idempotencyKey, authorizations, tossPaymentsRequest);
     }
 }

--- a/src/main/java/com/irum/paymentservice/openfeign/toss/client/TosspaymentsClient.java
+++ b/src/main/java/com/irum/paymentservice/openfeign/toss/client/TosspaymentsClient.java
@@ -12,5 +12,6 @@ import org.springframework.web.bind.annotation.RequestHeader;
 public interface TosspaymentsClient {
     @PostMapping("/v1/payments/confirm")
     TossPaymentsResponse confirmPayment(
+            @RequestHeader("idempotency-key") String idempotencyKey,
             @RequestHeader("Authorization") String auth, @RequestBody TossPaymentsRequest request);
 }

--- a/src/main/java/com/irum/paymentservice/openfeign/toss/client/TosspaymentsClient.java
+++ b/src/main/java/com/irum/paymentservice/openfeign/toss/client/TosspaymentsClient.java
@@ -13,5 +13,6 @@ public interface TosspaymentsClient {
     @PostMapping("/v1/payments/confirm")
     TossPaymentsResponse confirmPayment(
             @RequestHeader("idempotency-key") String idempotencyKey,
-            @RequestHeader("Authorization") String auth, @RequestBody TossPaymentsRequest request);
+            @RequestHeader("Authorization") String auth,
+            @RequestBody TossPaymentsRequest request);
 }

--- a/src/main/resources/db/changelog/changes/ddl/001-create-table-payment.yaml
+++ b/src/main/resources/db/changelog/changes/ddl/001-create-table-payment.yaml
@@ -38,6 +38,9 @@ databaseChangeLog:
                   name: member_id
                   type: BIGINT
               - column:
+                  name: idempotency_key
+                  type: VARCHAR(255)
+              - column:
                   name: created_at
                   type: TIMESTAMP WITH TIME ZONE
                   constraints:

--- a/src/main/resources/db/changelog/changes/legacy/002-insert-default-payments.yaml
+++ b/src/main/resources/db/changelog/changes/legacy/002-insert-default-payments.yaml
@@ -36,6 +36,9 @@ databaseChangeLog:
                   name: member_id
                   valueNumeric: 1
               - column:
+                  name: idempotency_key
+                  value: "11111111-1111-1111-1111-111111111111"
+              - column:
                   name: created_at
                   valueDate: now()
               - column:
@@ -81,6 +84,9 @@ databaseChangeLog:
               - column:
                   name: member_id
                   valueNumeric: 1
+              - column:
+                  name: idempotency_key
+                  value: "22222222-2222-2222-2222-222222222222"
               - column:
                   name: created_at
                   valueDate: now()
@@ -129,6 +135,9 @@ databaseChangeLog:
                   name: member_id
                   valueNumeric: 1
               - column:
+                  name: idempotency_key
+                  value: "33333333-3333-3333-3333-333333333333"
+              - column:
                   name: created_at
                   valueDate: now()
               - column:
@@ -175,6 +184,9 @@ databaseChangeLog:
               - column:
                   name: member_id
                   valueNumeric: 1
+              - column:
+                  name: idempotency_key
+                  value: "44444444-4444-4444-4444-444444444444"
               - column:
                   name: created_at
                   valueDate: now()

--- a/src/test/java/com/irum/paymentservice/domain/payment/service/PaymentServiceTest.java
+++ b/src/test/java/com/irum/paymentservice/domain/payment/service/PaymentServiceTest.java
@@ -79,7 +79,8 @@ public class PaymentServiceTest {
         when(payment.getIdempotencyKey()).thenReturn(TEST_IDEMPOTENCY_KEY);
 
         // tosspaymentsAPI 호출
-        when(tosspaymentsAPI.confirmPayment(paymentRequest, TEST_AMOUNT, TEST_IDEMPOTENCY_KEY)).thenReturn(tossResponse);
+        when(tosspaymentsAPI.confirmPayment(paymentRequest, TEST_AMOUNT, TEST_IDEMPOTENCY_KEY))
+                .thenReturn(tossResponse);
 
         // when
         PaymentResponse response = paymentService.createPayment(paymentRequest);
@@ -92,7 +93,8 @@ public class PaymentServiceTest {
         // 한번 호출
         verify(paymentRepository, times(1)).findById(TEST_PAYMENT_ID);
         verify(memberUtil, times(1)).assertMemberResourceAccess(TEST_MEMBER_ID);
-        verify(tosspaymentsAPI, times(1)).confirmPayment(paymentRequest, TEST_AMOUNT, TEST_IDEMPOTENCY_KEY);
+        verify(tosspaymentsAPI, times(1))
+                .confirmPayment(paymentRequest, TEST_AMOUNT, TEST_IDEMPOTENCY_KEY);
         verify(payment, times(1)).updateToPaid(tossResponse);
         verify(paymentEventProducer, times(1))
                 .sendPaymentPaidEvent(OrderStatus.PREPARING, TEST_ORDER_ID);
@@ -160,7 +162,8 @@ public class PaymentServiceTest {
                         Collections.emptyMap(),
                         (byte[]) null,
                         null);
-        when(tosspaymentsAPI.confirmPayment(any(PaymentRequest.class), eq(TEST_AMOUNT), eq(TEST_IDEMPOTENCY_KEY)))
+        when(tosspaymentsAPI.confirmPayment(
+                        any(PaymentRequest.class), eq(TEST_AMOUNT), eq(TEST_IDEMPOTENCY_KEY)))
                 .thenThrow(
                         new FeignException.InternalServerError("결제실패", dummyRequest, null, null));
 
@@ -171,7 +174,8 @@ public class PaymentServiceTest {
                 .isEqualTo(PaymentErrorCode.PAYMENT_ERROR);
 
         // then
-        verify(tosspaymentsAPI, times(1)).confirmPayment(paymentRequest, TEST_AMOUNT, TEST_IDEMPOTENCY_KEY);
+        verify(tosspaymentsAPI, times(1))
+                .confirmPayment(paymentRequest, TEST_AMOUNT, TEST_IDEMPOTENCY_KEY);
         // 실패 로직 1번씩 호출
         verify(paymentEventProducer, times(1)).sendPaymentFailedEvent(any(), any(), any());
         // 성공 로직 호출 x

--- a/src/test/java/com/irum/paymentservice/domain/payment/service/PaymentServiceTest.java
+++ b/src/test/java/com/irum/paymentservice/domain/payment/service/PaymentServiceTest.java
@@ -47,6 +47,7 @@ public class PaymentServiceTest {
     private TossPaymentsResponse tossResponse;
     private final UUID TEST_PAYMENT_ID = UUID.randomUUID();
     private final UUID TEST_ORDER_ID = UUID.randomUUID();
+    private final String TEST_IDEMPOTENCY_KEY = UUID.randomUUID().toString();
     private final String TEST_ORDER_NUM = "ORD-0000000";
     private final Long TEST_MEMBER_ID = 123L;
     private final int TEST_AMOUNT = 10000;
@@ -75,9 +76,10 @@ public class PaymentServiceTest {
 
         when(payment.getPaymentStatus()).thenReturn(PaymentStatus.PENDING);
         when(payment.getAmount()).thenReturn(TEST_AMOUNT);
+        when(payment.getIdempotencyKey()).thenReturn(TEST_IDEMPOTENCY_KEY);
 
         // tosspaymentsAPI 호출
-        when(tosspaymentsAPI.confirmPayment(paymentRequest, TEST_AMOUNT)).thenReturn(tossResponse);
+        when(tosspaymentsAPI.confirmPayment(paymentRequest, TEST_AMOUNT, TEST_IDEMPOTENCY_KEY)).thenReturn(tossResponse);
 
         // when
         PaymentResponse response = paymentService.createPayment(paymentRequest);
@@ -90,7 +92,7 @@ public class PaymentServiceTest {
         // 한번 호출
         verify(paymentRepository, times(1)).findById(TEST_PAYMENT_ID);
         verify(memberUtil, times(1)).assertMemberResourceAccess(TEST_MEMBER_ID);
-        verify(tosspaymentsAPI, times(1)).confirmPayment(paymentRequest, TEST_AMOUNT);
+        verify(tosspaymentsAPI, times(1)).confirmPayment(paymentRequest, TEST_AMOUNT, TEST_IDEMPOTENCY_KEY);
         verify(payment, times(1)).updateToPaid(tossResponse);
         verify(paymentEventProducer, times(1))
                 .sendPaymentPaidEvent(OrderStatus.PREPARING, TEST_ORDER_ID);
@@ -113,7 +115,7 @@ public class PaymentServiceTest {
                 .isEqualTo(PaymentErrorCode.PAYMENT_NOT_FOUND);
 
         verify(memberUtil, never()).assertMemberResourceAccess(anyLong());
-        verify(tosspaymentsAPI, never()).confirmPayment(any(), anyInt());
+        verify(tosspaymentsAPI, never()).confirmPayment(any(), anyInt(), anyString());
         verify(orderAPI, never()).updateOrderStatusPreparing(any(), any());
     }
 
@@ -133,7 +135,7 @@ public class PaymentServiceTest {
                 .extracting("errorCode")
                 .isEqualTo(PaymentErrorCode.PAYMENT_BAD_REQUEST);
 
-        verify(tosspaymentsAPI, never()).confirmPayment(any(), anyInt());
+        verify(tosspaymentsAPI, never()).confirmPayment(any(), anyInt(), anyString());
         verify(orderAPI, never()).updateOrderStatusPreparing(any(), any());
     }
 
@@ -148,6 +150,7 @@ public class PaymentServiceTest {
 
         when(payment.getPaymentStatus()).thenReturn(PaymentStatus.PENDING);
         when(payment.getAmount()).thenReturn(TEST_AMOUNT);
+        when(payment.getIdempotencyKey()).thenReturn(TEST_IDEMPOTENCY_KEY);
 
         // toss 호출 에러
         Request dummyRequest =
@@ -157,7 +160,7 @@ public class PaymentServiceTest {
                         Collections.emptyMap(),
                         (byte[]) null,
                         null);
-        when(tosspaymentsAPI.confirmPayment(any(PaymentRequest.class), eq(TEST_AMOUNT)))
+        when(tosspaymentsAPI.confirmPayment(any(PaymentRequest.class), eq(TEST_AMOUNT), eq(TEST_IDEMPOTENCY_KEY)))
                 .thenThrow(
                         new FeignException.InternalServerError("결제실패", dummyRequest, null, null));
 
@@ -168,7 +171,7 @@ public class PaymentServiceTest {
                 .isEqualTo(PaymentErrorCode.PAYMENT_ERROR);
 
         // then
-        verify(tosspaymentsAPI, times(1)).confirmPayment(paymentRequest, TEST_AMOUNT);
+        verify(tosspaymentsAPI, times(1)).confirmPayment(paymentRequest, TEST_AMOUNT, TEST_IDEMPOTENCY_KEY);
         // 실패 로직 1번씩 호출
         verify(paymentEventProducer, times(1)).sendPaymentFailedEvent(any(), any(), any());
         // 성공 로직 호출 x


### PR DESCRIPTION
## 🛠️ Issue Number
### closes #31 

📌 **작업 내용 및 특이사항**
- 현재 결제하기 로직에서 따로 쿠폰 차감이나 재고 차감을 진행하고 있지 않기 때문에 중복된 요청에 대해 멱등성 확보는 중복된 결제 제거로 이루어질 수 있다
- tosspayments API 요청시 헤더에 멱등키를 넣어 요청하면, 동일한 멱등키에 대해 별도의 로직 처리 없이 기존의 결과를 반환한다 
- 따라서 중복 결제를 방지할 수 있다 

DB수정 사항
- payment entity에 idempotency_key (VARCHAR(255)) 추가됨

📚 **참고사항**
