### PR TITLE
[Feature] PG사 에러 핸들링

### DIFF
--- a/src/main/java/com/irum/paymentservice/domain/payment/service/PaymentService.java
+++ b/src/main/java/com/irum/paymentservice/domain/payment/service/PaymentService.java
@@ -18,7 +18,6 @@ import com.irum.paymentservice.global.exception.errorcode.PaymentErrorCode;
 import com.irum.paymentservice.global.util.MemberUtil;
 import com.irum.paymentservice.openfeign.toss.TosspaymentsAPI;
 import com.irum.paymentservice.openfeign.toss.dto.TossPaymentsResponse;
-import feign.FeignException;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;

--- a/src/main/java/com/irum/paymentservice/domain/payment/service/PaymentService.java
+++ b/src/main/java/com/irum/paymentservice/domain/payment/service/PaymentService.java
@@ -65,12 +65,12 @@ public class PaymentService {
             return new PaymentResponse(payment.getAmount());
         } catch (PaymentAlreadyProcessedException e) {
             // 중복된 요청
-            log.info("중복된 결제 요청입니다: {}", e.getMessage());
+            log.info("중복된 결제 요청입니다 : {}", e.getMessage());
             return new PaymentResponse(payment.getAmount());
 
         } catch (PaymentRejectedException | PaymentTossServerException e) {
             // 재시도 대상이 아니거나, 재시도 횟수 초과시
-            log.warn("결제 승인 실패 {}", e.getMessage());
+            log.warn("결제 승인 실패 : {}", e.getMessage());
 
             // 상태 업데이트
             paymentStatusService.updatePaymentStatusFailed(payment.getPaymentId());
@@ -80,6 +80,12 @@ public class PaymentService {
                     request.orderId(), request.paymentId(), OrderStatus.FAILED);
             log.info("[외부] paymentFailedEvent 발행 완료");
 
+            throw new CommonException(PaymentErrorCode.PAYMENT_ERROR);
+        } catch (Exception e) {
+            log.error(
+                    " 예기치 못한 오류. message = {}, class = {}",
+                    e.getMessage(),
+                    e.getClass().toString());
             throw new CommonException(PaymentErrorCode.PAYMENT_ERROR);
         }
     }

--- a/src/main/java/com/irum/paymentservice/domain/payment/service/PaymentService.java
+++ b/src/main/java/com/irum/paymentservice/domain/payment/service/PaymentService.java
@@ -83,9 +83,7 @@ public class PaymentService {
             throw new CommonException(PaymentErrorCode.PAYMENT_ERROR);
         } catch (Exception e) {
             log.error(
-                    " 예기치 못한 오류. message = {}, class = {}",
-                    e.getMessage(),
-                    e.getClass().toString());
+                    "예기치 못한 오류. message = {}, class = {}", e.getMessage(), e.getClass().toString());
             throw new CommonException(PaymentErrorCode.PAYMENT_ERROR);
         }
     }

--- a/src/main/java/com/irum/paymentservice/domain/payment/service/PaymentService.java
+++ b/src/main/java/com/irum/paymentservice/domain/payment/service/PaymentService.java
@@ -10,6 +10,9 @@ import com.irum.paymentservice.domain.payment.domain.repository.PaymentRepositor
 import com.irum.paymentservice.domain.payment.dto.request.PaymentRequest;
 import com.irum.paymentservice.domain.payment.dto.response.PaymentResponse;
 import com.irum.paymentservice.domain.payment.producer.PaymentEventProducer;
+import com.irum.paymentservice.global.exception.business.PaymentAlreadyProcessedException;
+import com.irum.paymentservice.global.exception.business.PaymentRejectedException;
+import com.irum.paymentservice.global.exception.business.PaymentTossServerException;
 import com.irum.paymentservice.global.exception.errorcode.GlobalErrorCode;
 import com.irum.paymentservice.global.exception.errorcode.PaymentErrorCode;
 import com.irum.paymentservice.global.util.MemberUtil;
@@ -61,8 +64,14 @@ public class PaymentService {
             log.info("[외부] paymentPaidEvent 발행 완료");
 
             return new PaymentResponse(payment.getAmount());
-        } catch (FeignException e) {
-            // 추후에 Feign client error decoder로 변환하면 좋을 듯
+        } catch (PaymentAlreadyProcessedException e) {
+            // 중복된 요청
+            log.info("중복된 결제 요청입니다: {}", e.getMessage());
+            return new PaymentResponse(payment.getAmount());
+
+        } catch (PaymentRejectedException | PaymentTossServerException e) {
+            // 재시도 대상이 아니거나, 재시도 횟수 초과시
+            log.warn("결제 승인 실패 {}", e.getMessage());
 
             // 상태 업데이트
             paymentStatusService.updatePaymentStatusFailed(payment.getPaymentId());

--- a/src/main/java/com/irum/paymentservice/global/exception/business/PaymentAlreadyProcessedException.java
+++ b/src/main/java/com/irum/paymentservice/global/exception/business/PaymentAlreadyProcessedException.java
@@ -1,6 +1,6 @@
 package com.irum.paymentservice.global.exception.business;
 
-/** 보상 트랜잭션 제외 대상 (409, 422, 이미 처리된 결제)*/
+/** 보상 트랜잭션 제외 대상 (409, 422, 이미 처리된 결제) */
 public class PaymentAlreadyProcessedException extends RuntimeException {
     public PaymentAlreadyProcessedException(String message) {
         super(message);

--- a/src/main/java/com/irum/paymentservice/global/exception/business/PaymentAlreadyProcessedException.java
+++ b/src/main/java/com/irum/paymentservice/global/exception/business/PaymentAlreadyProcessedException.java
@@ -1,0 +1,8 @@
+package com.irum.paymentservice.global.exception.business;
+
+/** 보상 트랜잭션 제외 대상 (409, 422, 이미 처리된 결제)*/
+public class PaymentAlreadyProcessedException extends RuntimeException {
+    public PaymentAlreadyProcessedException(String message) {
+        super(message);
+    }
+}

--- a/src/main/java/com/irum/paymentservice/global/exception/business/PaymentRejectedException.java
+++ b/src/main/java/com/irum/paymentservice/global/exception/business/PaymentRejectedException.java
@@ -1,0 +1,8 @@
+package com.irum.paymentservice.global.exception.business;
+
+/** 보상 트랜잭션 대상 (4xx - 잔액 부족, 한도 초과 등) */
+public class PaymentRejectedException extends RuntimeException {
+    public PaymentRejectedException(String message) {
+        super(message);
+    }
+}

--- a/src/main/java/com/irum/paymentservice/global/exception/business/PaymentTossServerException.java
+++ b/src/main/java/com/irum/paymentservice/global/exception/business/PaymentTossServerException.java
@@ -1,0 +1,11 @@
+package com.irum.paymentservice.global.exception.business;
+
+import feign.Request;
+import feign.RetryableException;
+
+/** 재시도 대상인 에러일때 (5xx, timeout등) */
+public class PaymentTossServerException extends RetryableException {
+    public PaymentTossServerException(int status, String message, Request request) {
+        super(status, message, request.httpMethod(), (Long) null, request);
+    }
+}

--- a/src/main/java/com/irum/paymentservice/openfeign/config/FeignConfig.java
+++ b/src/main/java/com/irum/paymentservice/openfeign/config/FeignConfig.java
@@ -1,9 +1,8 @@
 package com.irum.paymentservice.openfeign.config;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
-import com.irum.paymentservice.openfeign.toss.error.TossPaymentErrorDecoder;
+import com.irum.paymentservice.openfeign.toss.decoder.TossPaymentErrorDecoder;
 import feign.Logger;
-import feign.RetryableException;
 import feign.Retryer;
 import feign.codec.ErrorDecoder;
 import lombok.RequiredArgsConstructor;

--- a/src/main/java/com/irum/paymentservice/openfeign/config/FeignConfig.java
+++ b/src/main/java/com/irum/paymentservice/openfeign/config/FeignConfig.java
@@ -5,17 +5,15 @@ import com.irum.paymentservice.openfeign.toss.decoder.TossPaymentErrorDecoder;
 import feign.Logger;
 import feign.Retryer;
 import feign.codec.ErrorDecoder;
+import java.util.concurrent.TimeUnit;
 import lombok.RequiredArgsConstructor;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
-
-import java.util.concurrent.TimeUnit;
 
 @Configuration
 @RequiredArgsConstructor
 public class FeignConfig {
     private final ObjectMapper objectMapper;
-
 
     @Bean
     Logger.Level feignLoggerLevel() {

--- a/src/main/java/com/irum/paymentservice/openfeign/config/FeignConfig.java
+++ b/src/main/java/com/irum/paymentservice/openfeign/config/FeignConfig.java
@@ -1,14 +1,37 @@
 package com.irum.paymentservice.openfeign.config;
 
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.irum.paymentservice.openfeign.toss.error.TossPaymentErrorDecoder;
 import feign.Logger;
+import feign.RetryableException;
+import feign.Retryer;
+import feign.codec.ErrorDecoder;
+import lombok.RequiredArgsConstructor;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 
+import java.util.concurrent.TimeUnit;
+
 @Configuration
+@RequiredArgsConstructor
 public class FeignConfig {
+    private final ObjectMapper objectMapper;
+
 
     @Bean
     Logger.Level feignLoggerLevel() {
         return Logger.Level.FULL;
+    }
+
+    // 응답이 200이 아닐 경우 실행되는 로직
+    @Bean
+    public ErrorDecoder errorDecoder() {
+        return new TossPaymentErrorDecoder(objectMapper);
+    }
+
+    @Bean
+    public Retryer retryer() {
+        // 100ms 시작, 최대 1초 대기, 총 3회 시도, 1.5 지수 백오프
+        return new Retryer.Default(100L, TimeUnit.SECONDS.toMillis(1), 3);
     }
 }

--- a/src/main/java/com/irum/paymentservice/openfeign/toss/decoder/TossPaymentErrorDecoder.java
+++ b/src/main/java/com/irum/paymentservice/openfeign/toss/decoder/TossPaymentErrorDecoder.java
@@ -7,12 +7,11 @@ import com.irum.paymentservice.global.exception.business.PaymentTossServerExcept
 import com.irum.paymentservice.openfeign.toss.dto.TossPaymentsErrorResponse;
 import feign.Response;
 import feign.codec.ErrorDecoder;
+import java.io.IOException;
+import java.io.InputStream;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.http.HttpStatus;
-
-import java.io.IOException;
-import java.io.InputStream;
 
 @Slf4j
 @RequiredArgsConstructor
@@ -20,30 +19,37 @@ public class TossPaymentErrorDecoder implements ErrorDecoder {
     private final ObjectMapper objectMapper;
     private final ErrorDecoder defaultErrorDecoder = new Default();
 
-
     @Override
     public Exception decode(String methodKey, Response response) {
         HttpStatus status = HttpStatus.resolve(response.status());
 
         // 응답 파싱
         TossPaymentsErrorResponse errorResponse = parseErrorResponse(response);
-        String errorCode = (errorResponse != null) ?
-                errorResponse.code() : "UNKNOWN";
-        String errorMessage = (errorResponse != null) ?
-                errorResponse.message() : "No message";
+        String errorCode = (errorResponse != null) ? errorResponse.code() : "UNKNOWN";
+        String errorMessage = (errorResponse != null) ? errorResponse.message() : "No message";
 
         if (status.is5xxServerError()) {
-            log.warn("[Toss] Server Error: [{}]: code = {}, message = {}", response.status(), errorCode, errorMessage);
-            return new PaymentTossServerException(response.status(), errorMessage, response.request());
+            log.warn(
+                    "[Toss] Server Error: [{}]: code = {}, message = {}",
+                    response.status(),
+                    errorCode,
+                    errorMessage);
+            return new PaymentTossServerException(
+                    response.status(), errorMessage, response.request());
         } else if (status.is4xxClientError()) {
-            if ( status == HttpStatus.CONFLICT || status == HttpStatus.UNPROCESSABLE_ENTITY || "ALREADY_PROCESSED_PAYMENT".equals(errorCode)) {
-                log.info("[Toss] 중복된 요청입니다. : [{}] code = {}, message = {}", response.status(), errorCode, errorMessage);
+            if (status == HttpStatus.CONFLICT
+                    || status == HttpStatus.UNPROCESSABLE_ENTITY
+                    || "ALREADY_PROCESSED_PAYMENT".equals(errorCode)) {
+                log.info(
+                        "[Toss] 중복된 요청입니다. : [{}] code = {}, message = {}",
+                        response.status(),
+                        errorCode,
+                        errorMessage);
                 return new PaymentAlreadyProcessedException(errorMessage);
             }
             log.warn("[Toss] 결제 거절({}): code = {}, message = {}", status, errorCode, errorMessage);
             return new PaymentRejectedException(errorMessage);
         }
-
 
         return defaultErrorDecoder.decode(methodKey, response);
     }
@@ -59,6 +65,5 @@ public class TossPaymentErrorDecoder implements ErrorDecoder {
             log.error("[Toss] Error Response Parsing Failed", e);
             return null;
         }
-
     }
 }

--- a/src/main/java/com/irum/paymentservice/openfeign/toss/decoder/TossPaymentErrorDecoder.java
+++ b/src/main/java/com/irum/paymentservice/openfeign/toss/decoder/TossPaymentErrorDecoder.java
@@ -1,7 +1,5 @@
-package com.irum.paymentservice.openfeign.toss.error;
+package com.irum.paymentservice.openfeign.toss.decoder;
 
-import com.fasterxml.jackson.core.exc.StreamReadException;
-import com.fasterxml.jackson.databind.DatabindException;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.irum.paymentservice.global.exception.business.PaymentAlreadyProcessedException;
 import com.irum.paymentservice.global.exception.business.PaymentRejectedException;
@@ -12,7 +10,6 @@ import feign.codec.ErrorDecoder;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.http.HttpStatus;
-import org.springframework.web.bind.annotation.RestControllerAdvice;
 
 import java.io.IOException;
 import java.io.InputStream;
@@ -30,10 +27,10 @@ public class TossPaymentErrorDecoder implements ErrorDecoder {
 
         // 응답 파싱
         TossPaymentsErrorResponse errorResponse = parseErrorResponse(response);
-        String errorCode = (errorResponse != null && errorResponse.errorDetail() != null) ?
-                errorResponse.errorDetail().code() : "UNKNOWN";
-        String errorMessage = (errorResponse != null && errorResponse.errorDetail() != null) ?
-                errorResponse.errorDetail().message() : "No message";
+        String errorCode = (errorResponse != null) ?
+                errorResponse.code() : "UNKNOWN";
+        String errorMessage = (errorResponse != null) ?
+                errorResponse.message() : "No message";
 
         if (status.is5xxServerError()) {
             log.warn("[Toss] Server Error: [{}]: code = {}, message = {}", response.status(), errorCode, errorMessage);

--- a/src/main/java/com/irum/paymentservice/openfeign/toss/dto/TossPaymentsErrorResponse.java
+++ b/src/main/java/com/irum/paymentservice/openfeign/toss/dto/TossPaymentsErrorResponse.java
@@ -1,0 +1,13 @@
+package com.irum.paymentservice.openfeign.toss.dto;
+
+public record TossPaymentsErrorResponse (
+        String version,
+        String traceId,
+        ErrorDetail errorDetail
+){
+    public record ErrorDetail (
+            String code,
+            String message
+    ) {
+    }
+}

--- a/src/main/java/com/irum/paymentservice/openfeign/toss/dto/TossPaymentsErrorResponse.java
+++ b/src/main/java/com/irum/paymentservice/openfeign/toss/dto/TossPaymentsErrorResponse.java
@@ -1,8 +1,3 @@
 package com.irum.paymentservice.openfeign.toss.dto;
 
-public record TossPaymentsErrorResponse (
-        String code,
-        String message
-    ) {
-
-}
+public record TossPaymentsErrorResponse(String code, String message) {}

--- a/src/main/java/com/irum/paymentservice/openfeign/toss/dto/TossPaymentsErrorResponse.java
+++ b/src/main/java/com/irum/paymentservice/openfeign/toss/dto/TossPaymentsErrorResponse.java
@@ -1,13 +1,8 @@
 package com.irum.paymentservice.openfeign.toss.dto;
 
 public record TossPaymentsErrorResponse (
-        String version,
-        String traceId,
-        ErrorDetail errorDetail
-){
-    public record ErrorDetail (
-            String code,
-            String message
+        String code,
+        String message
     ) {
-    }
+
 }

--- a/src/main/java/com/irum/paymentservice/openfeign/toss/error/TossPaymentErrorDecoder.java
+++ b/src/main/java/com/irum/paymentservice/openfeign/toss/error/TossPaymentErrorDecoder.java
@@ -1,0 +1,67 @@
+package com.irum.paymentservice.openfeign.toss.error;
+
+import com.fasterxml.jackson.core.exc.StreamReadException;
+import com.fasterxml.jackson.databind.DatabindException;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.irum.paymentservice.global.exception.business.PaymentAlreadyProcessedException;
+import com.irum.paymentservice.global.exception.business.PaymentRejectedException;
+import com.irum.paymentservice.global.exception.business.PaymentTossServerException;
+import com.irum.paymentservice.openfeign.toss.dto.TossPaymentsErrorResponse;
+import feign.Response;
+import feign.codec.ErrorDecoder;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.http.HttpStatus;
+import org.springframework.web.bind.annotation.RestControllerAdvice;
+
+import java.io.IOException;
+import java.io.InputStream;
+
+@Slf4j
+@RequiredArgsConstructor
+public class TossPaymentErrorDecoder implements ErrorDecoder {
+    private final ObjectMapper objectMapper;
+    private final ErrorDecoder defaultErrorDecoder = new Default();
+
+
+    @Override
+    public Exception decode(String methodKey, Response response) {
+        HttpStatus status = HttpStatus.resolve(response.status());
+
+        // 응답 파싱
+        TossPaymentsErrorResponse errorResponse = parseErrorResponse(response);
+        String errorCode = (errorResponse != null && errorResponse.errorDetail() != null) ?
+                errorResponse.errorDetail().code() : "UNKNOWN";
+        String errorMessage = (errorResponse != null && errorResponse.errorDetail() != null) ?
+                errorResponse.errorDetail().message() : "No message";
+
+        if (status.is5xxServerError()) {
+            log.warn("[Toss] Server Error: [{}]: code = {}, message = {}", response.status(), errorCode, errorMessage);
+            return new PaymentTossServerException(response.status(), errorMessage, response.request());
+        } else if (status.is4xxClientError()) {
+            if ( status == HttpStatus.CONFLICT || status == HttpStatus.UNPROCESSABLE_ENTITY || "ALREADY_PROCESSED_PAYMENT".equals(errorCode)) {
+                log.info("[Toss] 중복된 요청입니다. : [{}] code = {}, message = {}", response.status(), errorCode, errorMessage);
+                return new PaymentAlreadyProcessedException(errorMessage);
+            }
+            log.warn("[Toss] 결제 거절({}): code = {}, message = {}", status, errorCode, errorMessage);
+            return new PaymentRejectedException(errorMessage);
+        }
+
+
+        return defaultErrorDecoder.decode(methodKey, response);
+    }
+
+    private TossPaymentsErrorResponse parseErrorResponse(Response response) {
+        if (response.body() == null) {
+            return null;
+        }
+
+        try (InputStream bodyIs = response.body().asInputStream()) {
+            return objectMapper.readValue(bodyIs, TossPaymentsErrorResponse.class);
+        } catch (IOException e) {
+            log.error("[Toss] Error Response Parsing Failed", e);
+            return null;
+        }
+
+    }
+}

--- a/src/main/java/com/irum/paymentservice/openfeign/toss/exception/TosspaymentsException.java
+++ b/src/main/java/com/irum/paymentservice/openfeign/toss/exception/TosspaymentsException.java
@@ -1,3 +1,0 @@
-package com.irum.paymentservice.openfeign.toss.exception;
-
-public class TosspaymentsException {}

--- a/src/main/resources/application-test.yaml
+++ b/src/main/resources/application-test.yaml
@@ -8,3 +8,16 @@ spring:
     jpa:
       hibernate:
         ddl-auto: create-drop
+
+
+service:
+  member:
+    base_url: localhost:8081
+  product:
+    base_url: localhost:8082
+  order:
+    base_url: localhost:8083
+  payment:
+    base_url: localhost:8084
+  ai:
+    base-url: localhost:8085

--- a/src/main/resources/application.yaml
+++ b/src/main/resources/application.yaml
@@ -11,3 +11,15 @@ spring:
   config:
     import:
       - optional:configserver:${CONFIG_SERVER_URL:http://localhost:8888}
+
+service:
+  member:
+    base_url: localhost:8081
+  product:
+    base_url: localhost:8082
+  order:
+    base_url: localhost:8083
+  payment:
+    base_url: localhost:8084
+  ai:
+    base-url: localhost:8085

--- a/src/test/java/com/irum/paymentservice/domain/payment/service/PaymentServiceTest.java
+++ b/src/test/java/com/irum/paymentservice/domain/payment/service/PaymentServiceTest.java
@@ -12,14 +12,12 @@ import com.irum.paymentservice.domain.payment.domain.repository.PaymentRepositor
 import com.irum.paymentservice.domain.payment.dto.request.PaymentRequest;
 import com.irum.paymentservice.domain.payment.dto.response.PaymentResponse;
 import com.irum.paymentservice.domain.payment.producer.PaymentEventProducer;
+import com.irum.paymentservice.global.exception.business.PaymentRejectedException;
 import com.irum.paymentservice.global.exception.errorcode.PaymentErrorCode;
 import com.irum.paymentservice.global.util.MemberUtil;
 import com.irum.paymentservice.openfeign.order.OrderAPI;
 import com.irum.paymentservice.openfeign.toss.TosspaymentsAPI;
 import com.irum.paymentservice.openfeign.toss.dto.TossPaymentsResponse;
-import feign.FeignException;
-import feign.Request;
-import java.util.Collections;
 import java.util.Optional;
 import java.util.UUID;
 import org.junit.jupiter.api.BeforeEach;
@@ -155,17 +153,9 @@ public class PaymentServiceTest {
         when(payment.getIdempotencyKey()).thenReturn(TEST_IDEMPOTENCY_KEY);
 
         // toss 호출 에러
-        Request dummyRequest =
-                Request.create(
-                        Request.HttpMethod.POST,
-                        "http://mock-toss-api/confirm",
-                        Collections.emptyMap(),
-                        (byte[]) null,
-                        null);
         when(tosspaymentsAPI.confirmPayment(
                         any(PaymentRequest.class), eq(TEST_AMOUNT), eq(TEST_IDEMPOTENCY_KEY)))
-                .thenThrow(
-                        new FeignException.InternalServerError("결제실패", dummyRequest, null, null));
+                .thenThrow(new PaymentRejectedException("결제실패"));
 
         // when then
         assertThatThrownBy(() -> paymentService.createPayment(paymentRequest))


### PR DESCRIPTION
## 🛠️ Issue Number
### closes #33 

📌 **작업 내용 및 특이사항**
- 오류 코드 분류
- 각 오류 코드에 맞춰 오류 발생시 이후 행동 처리

토스페이먼츠 응답 | CustomException | 설명
-- | -- | --
time out, 5xx 에러 코드 | `PaymentTossServerException` | 이 예외가 발생했을때 토스패이먼츠에 재요청을 시도한다
409, 422, 400(ALREADY_PROCESSED_PAYMENT) | `PaymentAlreadyProcessedException` | 이 예외가 발생하면 보상트랜잭션을 실행하지 않는다. 이유 : 이미 결제 처리한 요청에 대해 중복처리하고 있기 때문에 롤백하지 않는다 |   |  
이외 4xx | `PaymentRejectedException` | 잔액부족, 한도초과 등 예외이므로 재시도 하지 않고 바로 보상트랙잭션을 실행한다




📚 **참고사항**
